### PR TITLE
Fix 404 on stub_status config snippet

### DIFF
--- a/amplify-guide.md
+++ b/amplify-guide.md
@@ -183,7 +183,7 @@ If you're using NGINX Plus, then you need to configure either the *stub_status* 
 
 Without *stub_status* or the NGINX Plus status API, the agent will NOT be able to collect key NGINX metrics required for further monitoring and analysis.
 
-Add the *stub_status* configuration as follows. You may also grab this config snippet [here](https://gist.githubusercontent.com/ptreyes/0b34d184de75f95478eb/raw/11f40f1ab7efb4278142054a11cea32323202320/stub_status.conf):
+Add the *stub_status* configuration as follows. You may also grab this config snippet [here](https://gist.githubusercontent.com/nesb0t/275d2dd8752262bba9a0a9f217f79faa/raw/517d7a8cf3e0fef8af1534d4eef6de5132869100/stub_status.conf):
 
 ```
 


### PR DESCRIPTION
The gist linked for the stub_status config snippet returns a 404. Created a new gist and updated URL.