### PR TITLE
fix: bump hugo theme to 0.33.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,5 @@ module gitlab.com/f5/nginx/controller/product/nginx-amplify-doc
 go 1.18
 
 require (
-	github.com/nginxinc/nginx-hugo-theme v0.28.0 // indirect
+	github.com/nginxinc/nginx-hugo-theme v0.33.0 // indirect
 )


### PR DESCRIPTION
## Proposed changes
Update go.mod to the latest hugo theme version 0.33.0

- Fixes Coveo search
