### PR TITLE
Adding known issues page to document release notes

### DIFF
--- a/content/changelog.md
+++ b/content/changelog.md
@@ -1,0 +1,15 @@
+---
+title: "Changelog"
+description: "Learn about the latest updates, new features, and resolved bugs in NGINX Amplify"
+weight: 800
+toc: true
+---
+
+## Date Jul 12th, 2023
+
+ ### What's New
+- {{% icon-feature %}} **NGINX Amplify Beta UI**
+
+The new Amplify user interface is in beta!  To enable it, you can click the  "Try New UI" button in the upper right corner of your browser.  Please give it a try and let us know what you think by clicking the "Give Feedback" button in the upper right corner of your browser window.
+
+If you want to revert to the classic UI, you can navigate to the Settings page by clicking on the gear icon in the upper right corner of your browser and click "Switch to Classic UI".

--- a/content/known-issues.md
+++ b/content/known-issues.md
@@ -1,0 +1,7 @@
+---
+title: Known Issues
+weight: 100
+description: "List of known issues in the latest release of NGINX Amplify"
+toc: true
+tags: ["docs"]
+---


### PR DESCRIPTION
The Known Issues page is empty at the moment.  I would like to have the page in place in order to provide release notes when necessary.