### PR TITLE
draft: fix: remove # from beginning of code blocks

### DIFF
--- a/content/faq/nginx-amplify-agent.md
+++ b/content/faq/nginx-amplify-agent.md
@@ -50,7 +50,7 @@ Previous versions were powered by Python 2.6 and 2.7, depending on the target pl
 1. Download and run the install script.
 
   ```bash
-    # curl -sS -L -O \
+    curl -sS -L -O \
     https://github.com/nginxinc/nginx-amplify-agent/raw/master/packages/install.sh && \
     API_KEY='YOUR_API_KEY' sh ./install.sh
   ```
@@ -60,7 +60,7 @@ Previous versions were powered by Python 2.6 and 2.7, depending on the target pl
 2. Verify that the Agent has started.
 
    ```bash
-   # ps ax | grep -i 'amplify\-'
+   ps ax | grep -i 'amplify\-'
    2552 ?        S      0:00 amplify-agent
    ```
 
@@ -105,13 +105,13 @@ If you don't see the new system or NGINX in the web interface, or (some) metrics
 1. On Ubuntu/Debian use:
 
    ```bash
-   # dpkg -s nginx-amplify-agent
+   dpkg -s nginx-amplify-agent
    ```
 
 2. On CentOS and Red Hat use:
 
    ```bash
-   # yum info nginx-amplify-agent
+   yum info nginx-amplify-agent
    ```
 
 ### How Can I Update NGINX Amplify Agent?
@@ -119,14 +119,14 @@ If you don't see the new system or NGINX in the web interface, or (some) metrics
 1. On Ubuntu/Debian use:
 
    ```bash
-   # apt-get update && \
+   apt-get update && \
    apt-get install nginx-amplify-agent
    ```
 
 2. On CentOS use:
 
    ```bash
-   # yum makecache && \
+   yum makecache && \
    yum update nginx-amplify-agent
    ```
 

--- a/content/install-manage/configuring-agent.md
+++ b/content/install-manage/configuring-agent.md
@@ -124,7 +124,7 @@ address = 127.0.0.1:12000
 Restart the agent to have it reload the configuration and start listening on the specified IP address and port:
 
 ```bash
-# service amplify-agent restart
+service amplify-agent restart
 ```
 
 Make sure to [add the `syslog` settings]({{< relref "/install-manage/configuring-agent#configuring-syslog" >}}) to your NGINX configuration as well.

--- a/content/install-manage/installing-agent.md
+++ b/content/install-manage/installing-agent.md
@@ -18,7 +18,7 @@ Take the following steps to install the Agent:
 1. Download and run the install script.
 
    ```bash
-   # curl -sS -L -O \
+   curl -sS -L -O \
    https://github.com/nginxinc/nginx-amplify-agent/raw/master/packages/install.sh && \
    API_KEY='YOUR_API_KEY' sh ./install.sh
    ```
@@ -28,7 +28,7 @@ Take the following steps to install the Agent:
 2. Verify that the agent has started.
 
    ```bash
-   # ps ax | grep -i 'amplify\-'
+   ps ax | grep -i 'amplify\-'
    2552 ?        S      0:00 amplify-agent
    ```
 
@@ -39,20 +39,20 @@ Take the following steps to install the Agent:
 1. Add the NGINX public key.
 
    ```bash
-   # curl -fs http://nginx.org/keys/nginx_signing.key | apt-key add -
+   curl -fs http://nginx.org/keys/nginx_signing.key | apt-key add -
    ```
 
    or
 
    ```bash
-   # wget -q -O - \
+   wget -q -O - \
    http://nginx.org/keys/nginx_signing.key | apt-key add -
    ```
 
 2. Configure the repository as follows.
 
     ```bash
-    # codename=`lsb_release -cs` && \
+    codename=`lsb_release -cs` && \
     os=`lsb_release -is | tr '[:upper:]' '[:lower:]'` && \
     echo "deb http://packages.amplify.nginx.com/${os}/ ${codename} amplify-agent" > \
     /etc/apt/sources.list.d/nginx-amplify.list
@@ -61,20 +61,20 @@ Take the following steps to install the Agent:
 3. Verify the repository config file (Ubuntu 14.04 example follows).
 
     ```bash
-    # cat /etc/apt/sources.list.d/nginx-amplify.list
+    cat /etc/apt/sources.list.d/nginx-amplify.list
     deb http://packages.amplify.nginx.com/ubuntu/ trusty amplify-agent
     ```
 
 4. Update the package index files.
 
     ```bash
-    # apt-get update
+    apt-get update
     ```
 
 5. Install and run the agent.
 
     ```bash
-    # apt-get install nginx-amplify-agent
+    apt-get install nginx-amplify-agent
     ```
 
 ### Installing on CentOS, Red Hat Linux, or Amazon Linux
@@ -82,14 +82,14 @@ Take the following steps to install the Agent:
 1. Add the NGINX public key.
 
     ```bash
-    # curl -sS -L -O http://nginx.org/keys/nginx_signing.key && \
+    curl -sS -L -O http://nginx.org/keys/nginx_signing.key && \
     rpm --import nginx_signing.key
     ```
 
    or
 
     ```bash
-    # wget -q -O nginx_signing.key http://nginx.org/keys/nginx_signing.key && \
+    wget -q -O nginx_signing.key http://nginx.org/keys/nginx_signing.key && \
     rpm --import nginx_signing.key
     ```
 
@@ -98,13 +98,13 @@ Take the following steps to install the Agent:
    Use the first snippet below for CentOS and Red Hat Linux. The second one applies to Amazon Linux.
 
     ```bash
-    # release="7" && \
+    release="7" && \
     printf "[nginx-amplify]\nname=nginx amplify repo\nbaseurl=http://packages.amplify.nginx.com/centos/${release}/\$basearch\ngpgcheck=1\nenabled=1\n" > \
     /etc/yum.repos.d/nginx-amplify.repo
     ```
 
     ```bash
-    # release="latest" && \
+    release="latest" && \
     printf "[nginx-amplify]\nname=nginx amplify repo\nbaseurl=http://packages.amplify.nginx.com/amzn/${release}/\$basearch\ngpgcheck=1\nenabled=1\n" > \
     /etc/yum.repos.d/nginx-amplify.repo
     ```
@@ -112,7 +112,7 @@ Take the following steps to install the Agent:
 3. Verify the repository config file (RHEL 7.1 example follows).
 
     ```bash
-    # cat /etc/yum.repos.d/nginx-amplify.repo
+    cat /etc/yum.repos.d/nginx-amplify.repo
     [nginx-amplify]
     name=nginx repo
     baseurl=http://packages.amplify.nginx.com/centos/7/$basearch
@@ -123,19 +123,19 @@ Take the following steps to install the Agent:
 4. Update the package metadata.
 
     ```bash
-    # yum makecache
+    yum makecache
     ```
 
 5. Install and run the agent.
 
     ```bash
-    # yum install nginx-amplify-agent
+    yum install nginx-amplify-agent
     ```
 
 ## Creating the Config File from a Template
 
 ```bash
-# api_key="YOUR_API_KEY" && \
+api_key="YOUR_API_KEY" && \
 sed "s/api_key.*$/api_key = ${api_key}/" \
 /etc/amplify-agent/agent.conf.default > \
 /etc/amplify-agent/agent.conf
@@ -146,20 +146,20 @@ API_KEY is a unique API key assigned to your Amplify account. You will see your 
 ## Starting and Stopping the Agent
 
 ```bash
-# service amplify-agent start
+service amplify-agent start
 ```
 
 ```bash
-# service amplify-agent stop
+service amplify-agent stop
 ```
 
 ```bash
-# service amplify-agent restart
+service amplify-agent restart
 ```
 
 ## Verifying that the Agent Has Started
 
 ```bash
-# ps ax | grep -i 'amplify\-'
+ps ax | grep -i 'amplify\-'
 2552 ?        S      0:00 amplify-agent
 ```

--- a/content/install-manage/updating-agent.md
+++ b/content/install-manage/updating-agent.md
@@ -14,13 +14,13 @@ It is *highly* recommended that you periodically check for updates and install t
  1. Updating the Agent On Ubuntu/Debian
 
     ```bash
-    # apt-get update && \
+    apt-get update && \
     apt-get install nginx-amplify-agent
     ```
 
  2. Updating the Agent On CentOS/Red Hat
 
     ```bash
-    # yum makecache && \
+    yum makecache && \
     yum update nginx-amplify-agent
     ```

--- a/content/metrics-metadata/other-metrics.md
+++ b/content/metrics-metadata/other-metrics.md
@@ -21,7 +21,7 @@ To start monitoring PHP-FPM, follow the steps below:
 1. Make sure that your PHP-FPM status is enabled for at least one pool — if it's not, uncomment the `pm.status_path` directive for the pool. For PHP7 on Ubuntu, look inside the **/etc/php/7.0/fpm/pool.d** directory to find the pool configuration files. After you've uncommented the `pm.status_path`, please make sure to restart PHP-FPM.
 
    ```bash
-   # service php7.0-fpm restart
+   service php7.0-fpm restart
    ```
 
 2. {{< important >}} Check that NGINX, the Amplify Agent, and the PHP-FPM workers are all run under the same user ID (e.g. `www-data`). You may have to change the used ID for the nginx workers, fix the nginx directories permissions, and then restart the agent too. If there are multiple PHP-FPM pools configured with different user IDs, make sure the agent's user ID is included in the group IDs of the PHP-FPM workers. This is required in order for the agent to access the PHP-FPM pool socket when querying for metrics.{{< /important >}}
@@ -37,7 +37,7 @@ To start monitoring PHP-FPM, follow the steps below:
 4. Confirm that the PHP-FPM listen socket for the pool exists and has the right permissions.
 
    ```bash
-   # ls -la /var/run/php/php7.0-fpm.sock
+   ls -la /var/run/php/php7.0-fpm.sock
    srw-rw---- 1 www-data www-data 0 May 18 14:02 /var/run/php/php7.0-fpm.sock
    ```
 
@@ -65,7 +65,7 @@ To start monitoring PHP-FPM, follow the steps below:
 9. Restart the agent.
 
    ```bash
-   # service amplify-agent restart
+   service amplify-agent restart
    ```
 
 The agent should be able to detect the PHP-FPM master and workers, obtain the access to status, and collect the necessary metrics.


### PR DESCRIPTION
Removes # from the beginning of code blocks:
- Makes the text appear as comments (dark grey)
- Makes the commands fail on copy-paste