### PR TITLE
Upgrade nginx-hugo-theme to support newer versions of Hugo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,4 @@ netlify: clean
 	netlify deploy --build -d public --alias $(shell git branch --show-current)-branch 
 
 deploy-preview: hugo-mod
-	hugo --gc -d public/nginxaas/azure/ -b ${NETLIFY_DEPLOY_URL}/nginx-amplify
+	hugo --gc -d public/nginx-amplify -b ${NETLIFY_DEPLOY_URL}/nginx-amplify

--- a/Makefile
+++ b/Makefile
@@ -19,17 +19,17 @@ hugo-mod:
 
 # Builds using the Hugo "staging" environment
 # For deploys to docs.nginx.com only
-build-production:
+build-production: hugo-mod
 	hugo --gc -e production
 	
 # Builds using the Hugo "staging" environment
 # For deploys to docs-staging.nginx.com only
-build-staging:
+build-staging: hugo-mod
 	hugo --gc -e staging
 
 # Builds using the Hugo "development" environment
 # For deploys to docs-dev.nginx.com only
-build-dev:
+build-dev: hugo-mod
 	hugo --gc -e development
 
 # Runs the Hugo server with content marked as draft
@@ -47,3 +47,6 @@ docs:
 # Requires a netlify login.
 netlify: clean
 	netlify deploy --build -d public --alias $(shell git branch --show-current)-branch 
+
+deploy-preview: hugo-mod
+	hugo --gc -d public/nginxaas/azure/ -b ${NETLIFY_DEPLOY_URL}/nginx-amplify

--- a/README.md
+++ b/README.md
@@ -1,12 +1,136 @@
-# nginx-amplify-doc
-Public documentation for NGINX Amplify.
+# NGINX Amplify Documentation
 
-NGINX Amplify is a tool for comprehensive NGINX monitoring. With NGINX Amplify it's easy to proactively analyze and fix problems related to running and scaling NGINX-based web applications.
+This directory contains all of the user documentation for NGINX Amplify, as well as the requirements for linting, building, and publishing the documentation.
 
-You can use NGINX Amplify to do the following:
+Docs are written in Markdown. We build the docs using [Hugo](https://gohugo.io) and host them on [Netlify](https://www.netlify.com/).
 
- * Visualize and identify NGINX performance bottlenecks, overloaded servers, or potential DDoS attacks
- * Improve and optimize NGINX performance with intelligent advice and recommendations
- * Get notified when something is wrong with the OS or NGINX
- * Plan web application capacity and performance
- * Keep track of the systems running NGINX
+## Setup
+
+1. To install Hugo locally, refer to the [Hugo installation instructions](https://gohugo.io/getting-started/installing/).
+
+    > **NOTE**: We are currently running [Hugo v0.115.3](https://github.com/gohugoio/hugo/releases/tag/v0.115.3) in production.
+
+2. We use markdownlint to check that Markdown files are correct. Use `npm` to install markdownlint-cli:
+
+    ```shell
+    npm install -g markdownlint-cli   
+    ```
+
+## Local Docs Development
+
+To build the docs locally, run the desired `make` command from the docs directory:
+
+```text
+make clean          -   removes the local `public` directory, which is the default output path used by Hugo
+make docs           -   runs a local hugo server so you can view docs in your browser while you work
+make hugo-mod       -   cleans the Hugo module cache and fetches the latest version of the theme module
+make docs-drafts    -   runs the local hugo server and includes all docs marked with `draft: true`
+```
+
+## Linting
+
+- To run the markdownlint check, run the following command from the docs directory:
+
+    ```bash
+    markdownlint -c docs/mdlint_conf.json content
+    ```
+
+    Note: You can run this tool on an entire directory or on an individual file.
+
+## Add new docs
+
+### Generate a new doc file using Hugo
+
+To create a new doc file that contains all of the pre-configured Hugo front-matter and the docs task template, **run the following command in the docs directory**:
+
+`hugo new <SECTIONNAME>/<FILENAME>.<FORMAT>`
+
+For example:
+
+```shell
+hugo new getting-started/install.md
+```
+
+The default template -- task -- should be used for most docs. To create docs using the other content templates, you can use the `--kind` flag:
+
+```shell
+hugo new tutorials/deploy.md --kind tutorial
+```
+
+The available content types (`kind`) are:
+
+- concept: Helps a customer learn about a specific feature or feature set.
+- tutorial: Walks a customer through an example use case scenario; results in a functional PoC environment.
+- reference: Describes an API, command line tool, config options, etc.; should be generated automatically from source code. 
+- troubleshooting: Helps a customer solve a specific problem.
+- openapi: Contains front-matter and shortcode for rendering an openapi.yaml spec
+
+## How to format docs
+
+### How to format internal links
+
+Format links as [Hugo refs](https://gohugo.io/content-management/cross-references/).
+
+- File extensions are optional.
+- You can use relative paths or just the filename. (**Paths without a leading / are first resolved relative to the current page, then to the remainder of the site.**)
+- Anchors are supported.
+
+For example:
+
+```md
+To install <product>, refer to the [installation instructions]({{< ref "install" >}}).
+```
+
+### How to include images
+
+You can use the `img` [shortcode](#how-to-use-hugo-shortcodes) to add images into your documentation.
+
+1. Add the image to the static/img directory, or to the same directory as the doc you want to use it in.
+
+   - **DO NOT include a forward slash at the beginning of the file path.** This will break the image when it's rendered.
+     See the docs for the [Hugo relURL Function](https://gohugo.io/functions/relurl/#input-begins-with-a-slash) to learn more.
+
+1. Add the img shortcode:
+
+    {{< img src="<img-file.png>" >}}
+
+> Note: The shortcode accepts all of the same parameters as the [Hugo figure shortcode](https://gohugo.io/content-management/shortcodes/#figure).
+
+### How to use Hugo shortcodes
+
+You can use [Hugo shortcodes](/docs/themes/f5-hugo/layouts/shortcodes/) to do things like format callouts, add images, and reuse content across different docs.
+
+For example, to use the note callout:
+
+```md
+{{< note >}}Provide the text of the note here. {{< /note >}}
+```
+
+The callout shortcodes also support multi-line blocks:
+
+```md
+{{< caution >}}
+You should probably never do this specific thing in a production environment. 
+
+If you do, and things break, don't say we didn't warn you.
+{{< /caution >}}
+```
+
+Supported callouts:
+
+- `caution`
+- `important`
+- `note`
+- `see-also`
+- `tip`
+- `warning`
+
+A few more fun shortcodes:
+
+- `fa`: inserts a Font Awesome icon
+- `img`: include an image and define things like alt text and dimensions
+- `include`: include the content of a file in another file; the included file must be present in the content/includes directory
+- `link`: makes it possible to link to a file and prepend the path with the Hugo baseUrl
+- `openapi`: loads an OpenAPI spec and renders as HTML using ReDoc
+- `raw-html`: makes it possible to include a block of raw HTML
+- `readfile`: includes the content of another file in the current file; does not require the included file to be in a specific location

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module gitlab.com/f5/nginx/controller/product/nginx-amplify-doc
 
 go 1.18
 
-require (
-	github.com/nginxinc/nginx-hugo-theme v0.33.0 // indirect
-)
+require github.com/nginxinc/nginx-hugo-theme v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,7 @@ github.com/nginxinc/nginx-hugo-theme v0.28.0 h1:RHHvBmFk2Uptk+efLPSIuBd2elc3IOZP
 github.com/nginxinc/nginx-hugo-theme v0.28.0/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
 github.com/nginxinc/nginx-hugo-theme v0.33.0 h1:6mZdgxf5kNhInsrAXXiSlWXRy3fsP51lWKOdrvmkR6U=
 github.com/nginxinc/nginx-hugo-theme v0.33.0/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
+github.com/nginxinc/nginx-hugo-theme v0.34.0-alpha h1:8tKWnkhxP5Nk0V64v8rE9T3crusycohXl3wmOWc4uFk=
+github.com/nginxinc/nginx-hugo-theme v0.34.0-alpha/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=
+github.com/nginxinc/nginx-hugo-theme v0.34.0 h1:G7LPVq7w1ls6IS4+OkTwjhFb67rLCzPdfZvW1/sn2Cw=
+github.com/nginxinc/nginx-hugo-theme v0.34.0/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "public"
-  command = "hugo --gc -b $DEPLOY_PRIME_URL/nginx-amplify"
+  command = "make deploy-preview"
 
 [context.development]
   command = "make all-dev"
@@ -12,10 +12,10 @@
   command = "make all"
 
 [context.deploy-preview]
-  command = "hugo --gc -b $DEPLOY_PRIME_URL/nginx-amplify"
+  command = "make deploy-preview"
 
 [context.branch-deploy]
-  command = "hugo --gc -b $DEPLOY_PRIME_URL/nginx-amplify"
+  command = "make deploy-preview"
 
 [[headers]]
   for = "/*"


### PR DESCRIPTION
This PR updates the nginx-hugo-theme module to v0.34.0, which adds support for Hugo v0.115.3 (and subsequent newer releases). This upgrade is necessary to address security vulnerabilities in the earlier pinned version of Hugo.

- I have corrected any instances of the `img` shortcode where a leading slash was used in the file path, ensuring that the images will render properly in the built documentation. 
- The docs/README has been updated to match that used across the NGINX projects where we develop docs.
- The docs/makefile, netlify configs, and hugo configs have all been updated so they are also now in parity with the configurations used across the NGINX documentation projects.

Related PR: https://github.com/nginxinc/nginx-hugo-theme/pull/16

Once this PR is merged, the environment variables that are stored in Netlify for the nginx-hugo-theme version and hugo version will be updated accordingly.